### PR TITLE
fix inconsistent footer text

### DIFF
--- a/packages/website/src/components/course-layout.tsx
+++ b/packages/website/src/components/course-layout.tsx
@@ -43,7 +43,7 @@ const CourseLayout: React.FunctionComponent<ICourseLayoutProps> = ({
     >
       <header>{header}</header>
       <main>{children}</main>
-      <footer>© {new Date().getFullYear()} All Rights Reserved</footer>
+      <footer>© {new Date().getFullYear()} All Rights Reserved.</footer>
     </div>
   );
 };

--- a/packages/website/src/components/course-layout.tsx
+++ b/packages/website/src/components/course-layout.tsx
@@ -43,7 +43,7 @@ const CourseLayout: React.FunctionComponent<ICourseLayoutProps> = ({
     >
       <header>{header}</header>
       <main>{children}</main>
-      <footer>© {new Date().getFullYear()}</footer>
+      <footer>© {new Date().getFullYear()} All Rights Reserved</footer>
     </div>
   );
 };


### PR DESCRIPTION
While working through your latest workshop, I noticed the copyright information in the `course-layout.tsx` component didn't include the "All Rights Reseved" text that is on the main `layout.tsx` file. This PR adds the missing text to the footer and make things more consistent. 

If this is intentional, then feel free to disregard this request.   