### PR TITLE
Pass resolve to `doSetup`

### DIFF
--- a/packages/website/content/blog/fundamentals-v3/13-nullish-values/index.md
+++ b/packages/website/content/blog/fundamentals-v3/13-nullish-values/index.md
@@ -113,13 +113,13 @@ class ThingWithAsyncSetup {
   constructor() {
     this.setupPromise = new Promise((resolve) => {
       this.isSetup = false
-      return this.doSetup()
+      return this.doSetup(resolve)
     }).then(() => {
       this.isSetup = true
     })
   }
 
-  private async doSetup() {
+  private async doSetup(resolve: (value: unknown) => void) {
     // some async stuff
   }
 }


### PR DESCRIPTION
Is it possible for the `Promise` to ever resolve without passing the `resolve` callback to the `doSetup` method? Apologies if I got this wrong, happy to learn!