### PR TITLE
Fix: Remove new operator when initializing BigInt

### DIFF
--- a/packages/website/content/blog/fundamentals-v3/08-exercise-json-types/index.md
+++ b/packages/website/content/blog/fundamentals-v3/08-exercise-json-types/index.md
@@ -57,7 +57,7 @@ isJSON(class {})
 // @ts-expect-error
 isJSON(undefined)
 // @ts-expect-error
-isJSON(new BigInt(143))
+isJSON(BigInt(143))
 // @ts-expect-error
 isJSON(isJSON)
 ```
@@ -93,7 +93,7 @@ isJSON(class {})
 // @ts-expect-error
 isJSON(undefined)
 // @ts-expect-error
-isJSON(new BigInt(143))
+isJSON(BigInt(143))
 // @ts-expect-error
 isJSON(isJSON)
 ```


### PR DESCRIPTION
### Description
Using the `new` operator with BigInt() throws an error since it is not a void function and that is different from the expected error.
