### PR TITLE
Replace spread syntax with Object.assign

### DIFF
--- a/packages/website/content/blog/fundamentals-v3/06-union-and-intersection-types/index.md
+++ b/packages/website/content/blog/fundamentals-v3/06-union-and-intersection-types/index.md
@@ -261,7 +261,7 @@ function makeWeek(): Date & { end: Date } {
   const start = new Date()
   const end = new Date(start.valueOf() + ONE_WEEK)
 
-  return { ...start, end } // kind of Object.assign
+  return Object.assign(start, { end })
 }
 
 const thisWeek = makeWeek()


### PR DESCRIPTION
`Object.assign` is necessary here as the spread syntax will not copy over properties from the prototype of `Date`.  Running the current code in the playground produces the error `thisWeek.toISOString is not a function`. See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals) on spread in object literals.

Also, thanks for this great intro to TypeScript.