### PR TITLE
Fix error creating BigInt instances

### DIFF
--- a/packages/website/content/blog/fundamentals-v3/08-exercise-json-types/index.md
+++ b/packages/website/content/blog/fundamentals-v3/08-exercise-json-types/index.md
@@ -57,7 +57,7 @@ isJSON(class {})
 // @ts-expect-error
 isJSON(undefined)
 // @ts-expect-error
-isJSON(new BigInt(143))
+isJSON(BigInt(143))
 // @ts-expect-error
 isJSON(isJSON)
 ```
@@ -93,7 +93,7 @@ isJSON(class {})
 // @ts-expect-error
 isJSON(undefined)
 // @ts-expect-error
-isJSON(new BigInt(143))
+isJSON(BigInt(143))
 // @ts-expect-error
 isJSON(isJSON)
 ```


### PR DESCRIPTION
BigInts are created by calling `BigInt`, which is a factory function, not a constructor. `BigInt` is not instantiated with `new`.

This change fixes an error that @mike-north is puzzled by for a moment in the Frontend Masters course.