### PR TITLE
Update Workshop Setup Link

### DIFF
--- a/packages/website/content/blog/fundamentals-v3/01-intro/index.md
+++ b/packages/website/content/blog/fundamentals-v3/01-intro/index.md
@@ -85,7 +85,7 @@ window.setInterval
 
 As long as you can access the following websites, you should require no further setup :tada:
 
-- [The course website you're reading right now](https://fun-v3.typescript-training.com)
+- [The course website you're reading right now](https://www.typescript-training.com)
 - [The official TypeScript website](https://www.typescriptlang.org)
 
 <!-- ## Which of your TypeScript courses is right for me?


### PR DESCRIPTION
On TypeScript Fundamentals v3 > Intro page > First Workshop, 1st Link leads to a different broken site.

Link to the affected section of the page [https://www.typescript-training.com/course/fundamentals-v3/01-intro/#workshop-setup]